### PR TITLE
systemd: Use proper WantedBy target

### DIFF
--- a/contrib/elly.service
+++ b/contrib/elly.service
@@ -13,7 +13,7 @@ EnvironmentFile=/home/ch/.config/elly/env
 
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 
 # place in ~/.config/systemd/user; systemctl --user enable elly; systemctl --user start elly; journalctl --user -u elly
 # see https://www.freedesktop.org/software/systemd/man/systemd.service.html


### PR DESCRIPTION
This is what I get for not understanding systemd. This is how it works:

multi-user.target exists for system:

	❯ sudo systemctl status multi-user.target
	[sudo] password for ch:
	● multi-user.target - Multi-User System
	     Loaded: loaded (/lib/systemd/system/multi-user.target; static)
	     Active: active since Wed 2023-08-02 20:33:11 CEST; 14h ago
	       Docs: man:systemd.special(7)

	aug 02 20:33:11 gamma systemd[1]: Reached target Multi-User System.

multi-user.target does not exist for user:

	❯ systemctl status --user multi-user.target
	Unit multi-user.target could not be found.

default.target exists for user (note the last line):

	❯ systemctl status --user default.target
	● default.target - Main User Target
	     Loaded: loaded (/usr/lib/systemd/user/default.target; static)
	     Active: active since Wed 2023-08-02 20:35:37 CEST; 14h ago
	       Docs: man:systemd.special(7)

	aug 02 20:35:37 gamma systemd[2852]: Reached target Main User Target.

default.target also exists for system (note the last line, which is different):

	❯ sudo systemctl status  default.target
	● graphical.target - Graphical Interface
	     Loaded: loaded (/lib/systemd/system/graphical.target; static)
	     Active: active since Wed 2023-08-02 20:33:11 CEST; 14h ago
	       Docs: man:systemd.special(7)

	aug 02 20:33:11 gamma systemd[1]: Reached target Graphical Interface